### PR TITLE
Make changes at line 171

### DIFF
--- a/Data Structures/Stack/cStack.cpp
+++ b/Data Structures/Stack/cStack.cpp
@@ -168,8 +168,7 @@ cStack &cStack::operator=(const cStack &rObj)
     }
     if (true)
     {
-        cStack temp;
-        temp = rObj;
+        cStack temp = rObj;
         top = temp.top;
         temp.top = NULL;
         return *this;


### PR DESCRIPTION
Actually logic was to call a copy constructor for an intermediate object temp with initialization of called object data. Then assigning that data to called object. If we not  do initialization then to pointer(not call copy constructor)then 2 pointers will start pointing to a single stack